### PR TITLE
Update image_utils.py

### DIFF
--- a/streamdiffusion/image_utils.py
+++ b/streamdiffusion/image_utils.py
@@ -10,7 +10,7 @@ def denormalize(images: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:
     """
     Denormalize an image array to [0,1].
     """
-    return (images / 2 + 0.5).clamp(0, 1)
+    return (images.float() / 2 + 0.5).clamp(0, 1)
 
 
 def pt_to_numpy(images: torch.Tensor) -> np.ndarray:


### PR DESCRIPTION
The error "clamp_scalar_cpu" not implemented for 'Half' occurs because a tensor of type float16 (or Half precision) is being passed to the .clamp() function, which does not support this operation on the CPU.

To resolve this issue, you need to ensure that the tensor is in a format compatible with the .clamp() function.